### PR TITLE
Make PDF generation optional and provide markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ You need to provide 2 refs to the action, `head` and `base`. The action steps ar
 1. Fetch all the commits between the `head` and `base` refs
 2. Find any reference to JIRA ticket numbers, based on the `jira-code` you provide
 3. Will fetch the ticket titles using the `jira-host`, `jira-username` and `jira-password` you provide
-4. Will generate a pdf with the list of changed tickets, and output the file path under the `pdf` variable
-5. (OPTIONAL) If the `email-to` and `sendgrid-api-key` are provided, and email will be sent with the notes
+4. If `pdf` is set to true:
+   4.1. Will generate a pdf with the list of changed tickets, and output the file path under the `pdf` variable
+otherwise
+   4.2. Will generate markdown with the list of changed tickets, and output it under the `markdown` variable
+6. (OPTIONAL) If the `email-to` and `sendgrid-api-key` are provided, and email will be sent with the notes
 
 ## Credentials: Passwords vs API Tokens
 
@@ -83,6 +86,9 @@ Subject of the release email
 
 Name of the app or service
 
+### pdf
+If set to true, will generate pdf otherwise markdown, default: false
+
 ### unshallow
 
 If set to true, will unshallow the repository before fetching the commits, default: false
@@ -92,6 +98,9 @@ If set to true, will unshallow the repository before fetching the commits, defau
 ### `pdf`
 
 The path of the generated pdf
+
+### `markdown`
+The markdown generated
 
 ## Example usage
 
@@ -123,6 +132,7 @@ jobs:
         email-to: 'john@mycompany.org,jane@mycompany.org'
         sendgrid-api-key: ${{secrets.sendgrid_api_key}}
         app-name: 'My Awesome Service'
+        pdf: true
         unshallow: true
     - name: Process the pdf
       run: echo "The generated pdf was ${{ steps.pdf_generator.outputs.pdf }}"

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
   app-name:
     description: 'Name of the app or service'
     required: false
+  pdf:
+    description: 'If set to true, will return pdf output otherwise will return markdown output'
+    required: false
+    default: false
   unshallow:
     description: 'If set to true, will unshallow the repository before fetching the commits'
     required: false

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ const options = {
   jiraUsername: readString('jira-username'),
   jiraPassword: readString('jira-password'),
   unshallow: readBoolean('unshallow'),
+  pdf: readBoolean('pdf'),
   emailTo: readString('email-to'),
   emailSubject: readString('email-subject'),
   sendgridApiKey: readString('sendgrid-api-key'),
@@ -48,10 +49,14 @@ const options = {
 
 async function runAction() {
   try {
-    const { pdf } = await execute(options);
-
-    core.setOutput("pdf", pdf);
-    console.log("Generated pdf " + pdf);
+    const result = await execute(options);
+    if (options.pdf) {
+      core.setOutput("pdf", result.pdf);
+      console.log("Generated pdf " + pdf);
+    } else {
+      core.setOutput("markdown", result.markdown);
+      console.log("Generated markdown: " + result.markdown);
+    }
   } catch (e) {
     const message = e && e.message || 'Something went wrong';
     core.setFailed(message);


### PR DESCRIPTION
I tried using this action and it never generated any pdf.
Log output was always:
"Generated pdf undefined"

I tried fixing this by adding a pdf parameter and falling back to outputting markdown when it's set to false (default).
